### PR TITLE
Feature: Added Support For Setup Payload Logo And QRCode.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,11 @@
                         </div>
                         <div id="qrIOSRow">
                             <div id="iosAppLogo" style="padding-bottom: 5px;"></div>
-                            <div id='qrcodeIOSApp'></div>
+                            <div id='qrcodeIOSApp' style="padding-right: 40px;"></div>
+                        </div>
+                        <div id="setupPayloadRow" class="ms-auto">
+                            <div id="setupPayloadLogo" style="padding-bottom: 5px;"></div>
+                            <div id='setupPayloadQRCode'></div>
                         </div>
                     </div>
                   </div>
@@ -219,7 +223,11 @@
                         </div>
                         <div id="qrIOSRowQS">
                             <div id="iosAppLogoQS" style="padding-bottom: 5px;"></div>
-                            <div id='qrcodeIOSAppQS' style="padding-bottom: 40px;"></div>
+                            <div id='qrcodeIOSAppQS' style="padding-right: 40px;"></div>
+                        </div>
+                        <div id="setupPayloadRowQS" class="ms-auto">
+                            <div id="setupPayloadLogoQS" style="padding-bottom: 5px;"></div>
+                            <div id='setupPayloadQRCodeQS'></div>
                         </div>
                     </div>
                 </div>

--- a/js/index.js
+++ b/js/index.js
@@ -551,6 +551,35 @@ function buildAppLinks(){
         $("#iosAppLogoQS").html("<a href='" + ios_app_url + "' target='_blank'><img src='./assets/appstore_download.png' height='50' width='130'></a>");
         appURLsHTML = defaultAppURLsHTML;
     }
+
+    if (config["setup_payload"] && config["setup_payload_logo"]) {
+        new QRCode(document.getElementById("setupPayloadQRCode"), {
+            text: config["setup_payload"],
+            width: 128,
+            height: 128,
+            colorDark : "#000000",
+            colorLight : "#ffffff",
+	        correctLevel : QRCode.CorrectLevel.H
+            });
+
+        $("#setupPayloadLogo").html(`<img src=${config["setup_payload_logo"]} height='50' width='130'></a>`);
+
+        new QRCode(document.getElementById("setupPayloadQRCodeQS"), {
+            text: config["setup_payload"],
+            width: 128,
+            height: 128,
+            colorDark : "#000000",
+            colorLight : "#ffffff",
+	        correctLevel : QRCode.CorrectLevel.H
+            });
+
+        $("#setupPayloadLogoQS").html(`<img src=${config["setup_payload_logo"]} height='50' width='130'></a>`);
+
+    } else {
+        $("#setupPayloadRow").css("display", "none");
+        $("#setupPayloadRowQS").css("display", "none");
+    }
+
     if(appURLsHTML === defaultAppURLsHTML){
         $("#progressMsgQS").html("Firmware Image flashing is complete. " + appURLsHTML);
         $("#appDownloadLink").html(appURLsHTML);


### PR DESCRIPTION
This MR adds support to display any setup payload logo and QRCode in launchpad after flash if they have been provided through following TOML parameters in passed TOML :
```
setup_payload_logo = "<_YOUR_SETUP_PAYLOAD_LOGO_LINK_>"
setup_payload = "<_YOUR_SETUP_PAYLOAD_QR_CODE_LINK_>"