### PR TITLE
Added Functional Call To erase_flash In Minimal Launchpad

### DIFF
--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -69,6 +69,7 @@ async function downloadAndFlash() {
             eraseAll: false,
             compress: true,
         };
+        await esploader.erase_flash();
         await esploader.write_flash(flashOptions);
     } catch (error) {
     }


### PR DESCRIPTION
# What Does This PR Do?
- This PR adds a call to **esploader.erase_flash** to remove existing binaries from the chipset before initiating the flashing of new binaries.
<img width="1552" alt="image" src="https://github.com/espressif/esp-launchpad/assets/90703337/e6ec691d-6a01-4f4b-b638-267023ce145a">
