### PR TITLE
Fix: Terminate console commands with CR only

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1004,7 +1004,7 @@ function clearCommandInput() {
 async function writeCommandToDevice(commandText) {
     const textEncoder = new TextEncoder();
     if (!device.writable.locked) writer = device.writable.getWriter();
-    await writer.write(textEncoder.encode(commandText + "\r\n"));
+    await writer.write(textEncoder.encode(commandText + "\r"));
     writer.releaseLock();
 }
 

--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -431,7 +431,7 @@ async function sendCommand() {
     historyIndex = -1;
     commandInput.value = "";
     commandInput.style.height = null;
-    commandToSend = commandToSend + "\r\n";
+    commandToSend = commandToSend + "\r";
     await writer.write(textEncoder.encode(commandToSend));
     writer.releaseLock();
 }


### PR DESCRIPTION
## Description

This PR updates console command handling in the Launchpad UI to terminate commands using carriage return (`\r`) only instead of carriage return + line feed (`\r\n`).

Certain firmware console implementations process commands only when the final received byte is `\r`. Sending an additional `\n` leaves an extra byte in the input buffer, causing command parsing failures in some RainMaker firmware variants.

The change ensures consistent console behavior across both main and minimal Launchpad UIs without requiring modifications in device-side low-memory console libraries.

### Motivation

* Fix console command parsing issues observed with existing RainMaker firmware
* Maintain compatibility across both RainMaker and Matter-style examples
* Avoid requiring firmware-side changes for different console implementations
* Keep console behavior consistent across Launchpad variants

---

## Related

> Try Out Link: https://rushikeshpatange.github.io/esp-launchpad

### Dev and Test Env:
- Chip Used: ESP32-C3

### Firmware Validation Matrix

| Firmware Type | Firmware / Example | `help` Command Response | Remarks |
|---|---|---|---|
| RainMaker | wifi_matter_light | ✅ Responded correctly | Commands worked with CR-only termination |
| RainMaker | RainMaker_fan | ❌ No response | Console not enabled in firmware example |
| RainMaker | RainMaker_multi_device | ❌ No response | Console not enabled in firmware example |
| RainMaker | RainMaker_temperature_sensor | ❌ No response | Console not enabled in firmware example |
| Matter | All ESP32-C3 supported Matter firmware examples | ✅ Responded correctly | `matter help` command executed successfully |

### Validation Summary

#### Before Fix
- Commands sent with `\r\n`
- Matter firmware handled commands correctly
- Existing RainMaker firmware failed to process certain commands due to trailing `\n`

#### After Fix
- Commands sent with `\r` only
- Verified commands execute successfully on:
  - Existing RainMaker firmware
  - Matter firmware examples

---

## Testing

* Verified console commands execute successfully using CR-only termination
* Validated behavior in both main and minimal Launchpad UIs
* Tested compatibility with:
  - Existing RainMaker firmware
  - Matter firmware examples
* Confirmed no regression in serial console communication flow

---

## Checklist

* [x] 🚨 This PR does not introduce breaking changes.
* [x] Code is well-commented, especially in complex areas.
* [x] Git history is clean — commits are squashed to the minimum necessary.